### PR TITLE
Updated dependencies and add bonsai support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,30 +1,50 @@
+Metrics/BlockLength:
+  Max: 35
 
-MethodLength:
+Metrics/MethodLength:
   Max: 200
 
-LineLength:
+Layout/LineLength:
   Max: 160
 
-AbcSize:
+Metrics/AbcSize:
   Max: 100
 
-FileName:
+Naming/FileName:
   Enabled: false
 
-PerceivedComplexity:
+Metrics/PerceivedComplexity:
   Enabled: false
 
-CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   Enabled: false
 
-ClassLength:
+Metrics/ClassLength:
   Enabled: false
 
-IfUnlessModifier:
+Style/IfUnlessModifier:
   Enabled: false
 
-RegexpLiteral:
+Style/RegexpLiteral:
   Enabled: false
 
 Style/Documentation:
+  Enabled: false
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/GuardClause:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: ruby
+services:
+- docker
 cache:
 - bundler
 install:
 - bundle install
 rvm:
-- 2.0
-- 2.1
-- 2.2
 - 2.3.0
 - 2.4.1
 notifications:
@@ -19,17 +18,23 @@ script:
 - bundle exec rake default
 - gem build sensu-plugins-sftp.gemspec
 - gem install sensu-plugins-sftp-*.gem
+before_deploy:
+  bash -c "[ ! -d bonsai/ ] && git clone https://github.com/sensu/sensu-go-bonsai-asset.git bonsai || echo 'bonsai/ exists, skipping git clone'"
 deploy:
-  provider: rubygems
+- provider: rubygems
   api_key:
     secure: Tb1NSE8FqOOSNtrnBHuTczrCLIuBp0RFMS6d1TadVK1jX2J4hylovgTANqq58CFxyu5NTc80qBXPxDh9SR1w2o2c43aMVUKHjKAtDFjav8LztsoYBWoxEwqCd2uwo5e4kUQ15ybh3fXpyxVH8ce9CQYYXllFkZVKUSKXoPVxx/Q=
   gem: sensu-plugins-sftp
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
-    rvm: 2.1
-    rvm: 2.2
     rvm: 2.3.0
     rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-sftp
+- provider: script
+  script: bonsai/ruby-runtime/travis-build-ruby-plugin-assets.sh sensu-plugins-sftp
+  skip_cleanup: true
+  on:
+    tags: true
+    all_branches: true
+    rvm: 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Breaking Changes
+- Update minimum required ruby version to 2.3. Drop unsupported ruby versions.
+- Bump `sensu-plugin` dependency to `~> 4.0`
+
+### Added
+- Bonsai asset support
+### Changed
+- Updated bundler dependancy to '~> 2.1'
+- Updated rubocop dependency to '~> 0.81.0'
+- Remediated rubocop issues
+- Updated rake dependency to '~> 13.0'
+- Updated net-sftp dependency to '2.1.2'
+
 ## [1.0.1] - 2017-09-20
 ### Fixed
 - Corrected Auth Method in Net::SFTP.start (@makaveli0129)

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-sftp.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'github/markup'
 require 'redcarpet'
@@ -7,9 +9,9 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -27,7 +29,7 @@ desc 'Test for binstubs'
 task :check_binstubs do
   bin_list = Gem::Specification.load('sensu-plugins-sftp.gemspec').executables
   bin_list.each do |b|
-    `which #{ b }`
+    `which #{b}`
     unless $CHILD_STATUS.success?
       puts "#{b} was not a binstub"
       exit
@@ -35,4 +37,4 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/bin/check-sftp.rb
+++ b/bin/check-sftp.rb
@@ -1,4 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   check-sftp
 #
@@ -110,7 +112,7 @@ class CheckSftp < Sensu::Plugin::Check::CLI
     critical "Failed authentication with #{config[:username]}"
   rescue Net::SFTP::StatusException => e
     critical "SFTP Error - #{e.message}"
-  rescue => e
+  rescue => e # rubocop: disable Style/RescueStandardError
     critical "Unexpected error; #{e.inspect}"
   end
 
@@ -149,6 +151,6 @@ class CheckSftp < Sensu::Plugin::Check::CLI
     @sftp ||= Net::SFTP.start(config[:host], config[:username], password: config[:password],
                                                                 timeout: config[:timeout],
                                                                 port: config[:port],
-                                                                auth_methods: %w(publickey password))
+                                                                auth_methods: %w[publickey password])
   end
 end

--- a/lib/sensu-plugins-sftp.rb
+++ b/lib/sensu-plugins-sftp.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'sensu-plugins-sftp/version'

--- a/lib/sensu-plugins-sftp/version.rb
+++ b/lib/sensu-plugins-sftp/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SensuPluginsSftp
   # This defines the version of the gem
   module Version

--- a/sensu-plugins-sftp.gemspec
+++ b/sensu-plugins-sftp.gemspec
@@ -1,4 +1,6 @@
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
@@ -13,34 +15,34 @@ Gem::Specification.new do |s|
                               file write access, and more'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-sftp'
   s.license                = 'MIT'
-  s.metadata               = { 'maintainer'         => 'sensu-plugin',
+  s.metadata               = { 'maintainer' => 'sensu-plugin',
                                'development_status' => 'active',
-                               'production_status'  => 'unstable - testing recommended',
-                               'release_draft'      => 'false',
+                               'production_status' => 'unstable - testing recommended',
+                               'release_draft' => 'false',
                                'release_prerelease' => 'false' }
   s.name                   = 'sensu-plugins-sftp'
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.3.0'
 
   s.summary                = 'Sensu plugins for sftp'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsSftp::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'net-sftp', '2.1.0'
+  s.add_runtime_dependency 'net-sftp', '2.1.2'
+  s.add_runtime_dependency 'sensu-plugin', '~> 4.0'
 
-  s.add_development_dependency 'bundler',                   '~> 1.7'
+  s.add_development_dependency 'bundler',                   '~> 2.1'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   s.add_development_dependency 'github-markup',             '~> 3.0'
   s.add_development_dependency 'pry',                       '~> 0.10'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
-  s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rake',                      '~> 12.3'
+  s.add_development_dependency 'rake',                      '~> 13.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
+  s.add_development_dependency 'rspec',                     '~> 3.1'
+  s.add_development_dependency 'rubocop',                   '~> 0.81.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start


### PR DESCRIPTION
- Update minimum required ruby version to 2.3. Drop unsupported ruby versions.
- Bump `sensu-plugin` dependency to `~> 4.0`
- Bonsai asset support
- Updated bundler dependancy to '~> 2.1'
- Updated rubocop dependency to '~> 0.81.0'
- Remediated rubocop issues
- Updated rake dependency to '~> 13.0'
- Updated net-sftp dependency to '2.1.2'

Signed-off-by: Todd Campbell <todd@sensu.io>

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatability Issues

