### PR TITLE
fix frozen_string_literal in bin/check-sftp.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [2.1.1] - 2020-06-25
+### Changed
+- Change frozen_string_literal to false in the check
+
 ## [2.1.0] - 2020-05-15
 ### Added
 - Bonsai asset support, missed .bonsai.yml before
@@ -54,7 +58,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-sftp/compare/2.1.0...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-sftp/compare/2.1.1...HEAD
+[2.1.1]: https://github.com/sensu-plugins/sensu-plugins-sftp/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/sensu-plugins/sensu-plugins-sftp/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/sensu-plugins/sensu-plugins-sftp/compare/1.0.1...2.0.0
 [1.0.1]: https://github.com/sensu-plugins/sensu-plugins-sftp/compare/1.0.0...1.0.1

--- a/bin/check-sftp.rb
+++ b/bin/check-sftp.rb
@@ -1,5 +1,5 @@
 #! /usr/bin/env ruby
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #
 #   check-sftp

--- a/lib/sensu-plugins-sftp/version.rb
+++ b/lib/sensu-plugins-sftp/version.rb
@@ -5,7 +5,7 @@ module SensuPluginsSftp
   module Version
     MAJOR = 2
     MINOR = 1
-    PATCH = 0
+    PATCH = 1
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, fixes the frozen_string_literal: true in check-sftp.rb. 
Closes #21 


#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatability Issues

